### PR TITLE
Fix pre-released version output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ get_local_package_version() {
     GET_OUTPUT=`dart pub get`
     DEPS_OUTPUT=`dart pub deps`
   fi
-  PACKAGE_INFO=`echo "$DEPS_OUTPUT" | perl -0777 -pe 's/(└|│|-|├).+//s' | head -n 3`
+  PACKAGE_INFO=`echo "$DEPS_OUTPUT" | perl -0777 -pe 's/(└|│|├).+//s' | head -n 3`
   trace "$PACKAGE_INFO"
   DART_VERSION=`echo "$PACKAGE_INFO" | perl -n -e'/^Dart SDK (.*)$/ && print $1'`
   FLUTTER_VERSION=`echo "$PACKAGE_INFO" | perl -n -e'/^Flutter SDK (.*)$/ && print $1'`


### PR DESCRIPTION
My current package version is `1.3.0-pre.1` because it is a pre-released version; that's why it contains the '-' suffix. The problem is that when I run this action, it truncates the suffix and becomes `1.3.0` instead.

I'm not very good at writing shell scripts, but I hope this PR can resolve this issue. Feel free to correct me.